### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ ansiblevault_path example:
 
 ```tf
 provider "ansiblevault" {
-  vault_path  = "/home/username/.vault_pass.txt"
+  vault_pass  = "/home/username/.vault_pass.txt"
   root_folder = "/home/username/infra/ansible/"
 }
 


### PR DESCRIPTION
Fix an incorrectly named attribute in usage example.

# Before creating my pull-request, I ensure:

- [x] Documentation is written
- [ ] Unit tests are written and green
- [x] I've cleaned my WIP or meaningless commits
- [ ] Examples are up-to-date

# In order to validate the pull request, I do:

- I hope this is a genuine typo, but hopefully so, given the examples use _vault_pass_ in this place
